### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/gtracy/memories/security/code-scanning/1](https://github.com/gtracy/memories/security/code-scanning/1)

In general, fix this by adding an explicit `permissions:` section to the workflow or to the specific job so that the `GITHUB_TOKEN` has only the scopes required. For this workflow, no GitHub write operations are performed (no pushes, releases, issue/PR modifications, etc.), only reading the repository via `actions/checkout`. Therefore, `contents: read` is sufficient and matches CodeQL’s suggested minimal configuration.

The best fix without changing functionality is to add a job-level `permissions:` block under `jobs.deploy:` specifying `contents: read`. This keeps the scope local to this job and does not affect any other jobs in the file (if they are added later). Concretely, in `.github/workflows/deploy-lambda.yml`, insert:

```yaml
    permissions:
      contents: read
```

directly under the `runs-on: ubuntu-latest` line (line 10 in the snippet). No other steps, commands, or secrets usage need to change. No additional methods or imports are required since this is purely a workflow configuration change in YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
